### PR TITLE
chore: add repository field to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,6 +5,7 @@ authors = ["David Sherret <dsherret@gmail.com>"]
 edition = "2018"
 license = "MIT"
 description = "Information about lines of text in a string."
+repository = "https://github.com/dsherret/text_lines"
 
 [features]
 serialization = ["serde"]


### PR DESCRIPTION
Hi! While scraping crates.io I've found this crate to be missing the `repository` field, making it harder for users and automated tools to find the git repository. This fixes it.